### PR TITLE
Enforce timestamp

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -23,6 +23,7 @@
 
 #include "GameLoader.h"
 #include "LibraryInjector.h"
+#include "TimeChecker.h"
 
 int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
         LPSTR lpCmdLine, int nCmdShow) {
@@ -31,6 +32,8 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     std::cout << "Affero General Public License, version 3 or greater." << std::endl;
 
     //ShowWindow(GetConsoleWindow(), SW_HIDE);
+    TimeChecker::enforceTimeStamp();
+
     PROCESS_INFORMATION processInformation;
     startGame(&processInformation);
     LibraryInjector::injectLibraries(&processInformation);

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -30,6 +30,7 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     std::cout << "SlashDiablo Game Loader - Copyright (C) 2018 Mir Drualga" << std::endl;
     std::cout << "This program is free software, licensed under the" << std::endl;
     std::cout << "Affero General Public License, version 3 or greater." << std::endl;
+    std::cout << std::endl;
 
     //ShowWindow(GetConsoleWindow(), SW_HIDE);
     TimeChecker::enforceTimeStamp();
@@ -38,6 +39,8 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     // startGame function can return.
     PROCESS_INFORMATION processInformation;
     startGame(&processInformation);
+
+    // Inject libraries, after reading all files.
     LibraryInjector::injectLibraries(&processInformation);
 
     return 0;

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -34,6 +34,8 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
     //ShowWindow(GetConsoleWindow(), SW_HIDE);
     TimeChecker::enforceTimeStamp();
 
+    // Create a new process, waiting for its full initialization before the
+    // startGame function can return.
     PROCESS_INFORMATION processInformation;
     startGame(&processInformation);
     LibraryInjector::injectLibraries(&processInformation);

--- a/src/TimeChecker.cpp
+++ b/src/TimeChecker.cpp
@@ -1,0 +1,25 @@
+/**
+ * SlashDiablo Game Loader
+ * Copyright (C) 2018 Mir Drualga
+ *
+ *  This file is part of SlashDiablo Game Loader.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "TimeChecker.h"
+
+bool TimeChecker::isExecutionPermitted() {
+    return true;
+}

--- a/src/TimeChecker.cpp
+++ b/src/TimeChecker.cpp
@@ -20,6 +20,53 @@
 
 #include "TimeChecker.h"
 
+#include <windows.h>
+#include <chrono>
+#include <iostream>
+#include <regex>
+#include <unordered_map>
+
+std::chrono::system_clock TimeChecker::convertStringDate(
+        std::string_view dateString) {
+    static const std::unordered_map<std::string, int> monthValues = {
+        { "Jan", 0 }, { "Feb", 1 }, { "Mar", 2 }, { "Apr", 3 }, { "May", 4 },
+        { "Jun", 5 }, { "Jul", 6 }, { "Aug", 7 }, { "Sep", 8 }, { "Oct", 9 },
+        { "Nov", 10 }, { "Dec", 11 }
+    };
+
+    std::cout << dateString.data() <<std::endl;
+    const std::regex COMPILE_DATE_REGEX("(\\s+) (\\d+) (\\d+)");
+    std::cmatch matches;
+
+    struct tm timeInfo;
+    if (!std::regex_match(dateString.data(), matches, COMPILE_DATE_REGEX)) {
+        return std::chrono::system_clock();
+    }
+
+    std::cout << matches[0] << std::endl;
+    std::cout << matches[1] << std::endl;
+    std::cout << matches[2] << std::endl;
+    std::cout << matches[3] << std::endl;
+}
+
+void TimeChecker::enforceTimeStamp() {
+    if constexpr (!ENFORCE_TIMESTAMP) {
+        return;
+    }
+
+    std::cout << "Timestamp is enforced, meaning that this program " <<
+        "will cease to function on " << COMPILATION_DATE << "." << std::endl;
+    std::cout << "This means that you have received a version of the " <<
+        "program not meant for public release." << std::endl;
+
+    if (!isExecutionPermitted()) {
+        MessageBoxW(nullptr, L"Date of execution exceeds timestamp limit.",
+            L"Execution Date Exceeded", MB_OK | MB_ICONERROR);
+        std::exit(0);
+    }
+}
+
 bool TimeChecker::isExecutionPermitted() {
+    convertStringDate(COMPILATION_DATE);
     return true;
 }

--- a/src/TimeChecker.h
+++ b/src/TimeChecker.h
@@ -1,0 +1,37 @@
+/**
+ * SlashDiablo Game Loader
+ * Copyright (C) 2018 Mir Drualga
+ *
+ *  This file is part of SlashDiablo Game Loader.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifndef TIMECHECKER_H
+#define TIMECHECKER_H
+
+class TimeChecker {
+public:
+    static constexpr bool ENFORCE_TIME_STAMP = true;
+    static constexpr const char *COMPILATION_DATE = __DATE__;
+
+    static bool isExecutionPermitted();
+
+    TimeChecker() = delete;
+private:
+};
+
+#endif // TIMECHECKER_H

--- a/src/TimeChecker.h
+++ b/src/TimeChecker.h
@@ -30,9 +30,10 @@ class TimeChecker {
 public:
     static constexpr bool ENFORCE_TIMESTAMP = true;
     static constexpr const char *COMPILATION_DATE = __DATE__;
+    static constexpr int ALLOWED_MONTH_DIFFERENCE = 1;
 
-    static std::chrono::system_clock convertStringDate(
-        std::string_view dateString);
+    static std::chrono::duration<long long, std::ratio<2629746>>
+        getDaysFromDateString(std::string_view dateString);
     static void enforceTimeStamp();
     static bool isExecutionPermitted();
 

--- a/src/TimeChecker.h
+++ b/src/TimeChecker.h
@@ -23,11 +23,17 @@
 #ifndef TIMECHECKER_H
 #define TIMECHECKER_H
 
+#include <chrono>
+#include <string_view>
+
 class TimeChecker {
 public:
-    static constexpr bool ENFORCE_TIME_STAMP = true;
+    static constexpr bool ENFORCE_TIMESTAMP = true;
     static constexpr const char *COMPILATION_DATE = __DATE__;
 
+    static std::chrono::system_clock convertStringDate(
+        std::string_view dateString);
+    static void enforceTimeStamp();
     static bool isExecutionPermitted();
 
     TimeChecker() = delete;


### PR DESCRIPTION
Enforce timestamp rules, in order to discourage testers from publicly distributing binaries that are meant to be temporary. The timestamps allow for a program to be executed up to one month after the month (not day) the program is compiled.