### PR TITLE
Add suspend injection

### DIFF
--- a/SlashGaming-Game-Loader/src/library_injector.cc
+++ b/SlashGaming-Game-Loader/src/library_injector.cc
@@ -275,7 +275,48 @@ InjectLibrary(
     return false;
   }
 
-  WaitForSingleObject(remote_thread_handle, INFINITE);
+  DWORD wait_return_value = WaitForSingleObject(remote_thread_handle, INFINITE);
+  if (wait_return_value == 0xFFFFFFFF) {
+    std::wstring full_message = fmt::sprintf(
+        kFunctionFailErrorMessage.data(),
+        fmt::to_wstring(__FILE__),
+        __LINE__,
+        L"WaitForSingleObject",
+        GetLastError()
+    );
+
+    MessageBoxW(
+        nullptr,
+        full_message.data(),
+        L"WaitForSingleObject Failed",
+        MB_OK | MB_ICONERROR
+    );
+    return false;
+  }
+
+  DWORD thread_exit_code;
+  BOOL is_get_exit_code_thread_success = GetExitCodeThread(
+      remote_thread_handle,
+      &thread_exit_code
+  );
+
+  if (!is_get_exit_code_thread_success) {
+    std::wstring full_message = fmt::sprintf(
+        kFunctionFailErrorMessage.data(),
+        fmt::to_wstring(__FILE__),
+        __LINE__,
+        L"GetExitCodeThread",
+        GetLastError()
+    );
+
+    MessageBoxW(
+        nullptr,
+        full_message.data(),
+        L"GetExitCodeThread Failed",
+        MB_OK | MB_ICONERROR
+    );
+    return false;
+  }
 
   return true;
 }

--- a/SlashGaming-Game-Loader/src/library_injector.cc
+++ b/SlashGaming-Game-Loader/src/library_injector.cc
@@ -260,6 +260,8 @@ InjectLibrary(
   if (remote_thread_handle == nullptr) {
     std::wstring full_message = fmt::sprintf(
         kFunctionFailErrorMessage.data(),
+        fmt::to_wstring(__FILE__),
+        __LINE__,
         L"CreateRemoteThread",
         GetLastError()
     );

--- a/SlashGaming-Game-Loader/src/main.cc
+++ b/SlashGaming-Game-Loader/src/main.cc
@@ -94,7 +94,7 @@ main(
   // Create a new process.
   std::filesystem::path game_executable_path =
       GetGameExecutableFilePath(dll_handle);
-  PROCESS_INFORMATION process_info = StartGame(game_executable_path);
+  PROCESS_INFORMATION process_info = StartGameSuspended(game_executable_path);
 
   BOOST_SCOPE_EXIT(&process_info) {
     CloseHandle(process_info.hProcess);
@@ -108,6 +108,9 @@ main(
   } else {
     fmt::printf(u8"Some or all libraries failed to inject. \n");
   }
+
+  // Resume process.
+  ResumeThread(process_info.hThread);
 
   Sleep(500);
 


### PR DESCRIPTION
Instead of injecting concurrently with the process starting, the game loader now creates the process in a suspended state. This allows any state-sensitive patches (e.g. multibox patch) to inject without issue.