### PR TITLE
Fix output to executable

### DIFF
--- a/SGGL/CMakeLists.txt
+++ b/SGGL/CMakeLists.txt
@@ -69,7 +69,7 @@ set(SOURCE_FILES
     "src/license.h"
 )
 
-# Output DLL
+# Output EXE
 
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 

--- a/SGGL/CMakeLists.txt
+++ b/SGGL/CMakeLists.txt
@@ -71,6 +71,6 @@ set(SOURCE_FILES
 
 # Output DLL
 
-add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES})
+add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})


### PR DESCRIPTION
These changes fixes the CMakeLists build output type. It was previously a shared library, due to improper copy and pasting.