### PR TITLE
Refactor license code

### DIFF
--- a/SGGL/src/license.c
+++ b/SGGL/src/license.c
@@ -32,7 +32,11 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static const char* kLicenseLines[] = {
+/**
+ * External
+ */
+
+const char* const License_kText[] = {
     "SlashGaming Game Loader",
     "Copyright (C) 2018-2021  Mir Drualga",
     "",
@@ -54,13 +58,10 @@ static const char* kLicenseLines[] = {
     "information."
 };
 
-static const size_t kLicenseLinesCount =
-    sizeof(kLicenseLines) / sizeof(kLicenseLines[0]);
-
-void PrintLicenseNotice(void) {
+void License_PrintText(void) {
   size_t i;
 
-  for (i = 0; i < kLicenseLinesCount; i += 1) {
-    printf("%s \n", kLicenseLines[i]);
+  for (i = 0; i < License_kTextCount; ++i) {
+    puts(License_kText[i]);
   }
 }

--- a/SGGL/src/license.h
+++ b/SGGL/src/license.h
@@ -30,6 +30,20 @@
 #ifndef SGGL_LICENSE_H_
 #define SGGL_LICENSE_H_
 
-void PrintLicenseNotice(void);
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+enum {
+  License_kTextCount = 19,
+};
+
+extern const char* const License_kText[License_kTextCount];
+
+void License_PrintText(void);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif  /* SGGL_LICENSE_H_ */

--- a/SGGL/src/main.c
+++ b/SGGL/src/main.c
@@ -52,7 +52,7 @@ int wmain(int argc, const wchar_t** argv) {
   memset(&args, 0, sizeof(args));
 
   /* Print the license notice. */
-  PrintLicenseNotice();
+  License_PrintText();
 
   for (i = 0; i < 79; i += 1) {
     printf("-");


### PR DESCRIPTION
License text is now made extern, and naming scheme is changed to reflect namespace separated by underscores.