### PR TITLE
Refactor help printer

### DIFF
--- a/SGGL/CMakeLists.txt
+++ b/SGGL/CMakeLists.txt
@@ -83,3 +83,9 @@ set(SOURCE_FILES
 add_executable(${PROJECT_NAME} ${SOURCE_FILES})
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${SOURCE_FILES})
+
+target_link_libraries(${PROJECT_NAME}
+    libMDCc
+    shlwapi
+)
+add_dependencies(${PROJECT_NAME} libMDCc)

--- a/SGGL/src/help_printer.c
+++ b/SGGL/src/help_printer.c
@@ -29,36 +29,35 @@
 
 #include "help_printer.h"
 
-#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <windows.h>
 #include <shlwapi.h>
 
-enum CONSTANTS {
-  ARG_OPTION_LEN = 36,
-  DESCRIPTION_LEN = 72 - ARG_OPTION_LEN - 2
+#include <mdc/std/assert.h>
+#include <mdc/std/wchar.h>
+
+enum {
+  kArgOptionLength = 36,
+  kDescriptionLength = 72 - kArgOptionLength - 2
 };
 
-const char* kFormatString = "  %-34s %s \n";
-const char* kFormatContinueString = "%36c %s \n";
+#define FORMAT_STRING "  %-34s %s\n"
+#define FORMAT_CONTINUE_STRING "%36c %s\n"
 
 static void PrintArgHelp(
     const char* arg_option,
-    const char* description
-) {
-  assert(strlen(arg_option) < ARG_OPTION_LEN);
-  assert(strlen(description) < DESCRIPTION_LEN);
+    const char* description) {
+  assert(strlen(arg_option) < kArgOptionLength);
+  assert(strlen(description) < kDescriptionLength);
 
-  printf(kFormatString, arg_option, description);
+  printf(FORMAT_STRING, arg_option, description);
 }
 
-static void PrintContinuedLine(
-    const char* description
-) {
-  assert(strlen(description) < DESCRIPTION_LEN);
+static void PrintContinuedLine(const char* description) {
+  assert(strlen(description) < kDescriptionLength);
 
-  printf(kFormatContinueString, ' ', description);
+  printf(FORMAT_CONTINUE_STRING, ' ', description);
 }
 
 /**
@@ -73,25 +72,21 @@ void Help_PrintText(const wchar_t* program_path) {
 
   PrintArgHelp(
       "-a, --gameargs <args>",
-      "Command line arguments to pass to"
-  );
+      "Command line arguments to pass to");
   PrintContinuedLine("the game");
 
   PrintArgHelp(
       "-k, --knowledge <library>",
-      "Path of Knowledge extension"
-  );
+      "Path of Knowledge extension");
   PrintContinuedLine("library");
 
   PrintArgHelp(
       "-l, --library <library>",
-      "Path of library to inject (this"
-  );
+      "Path of library to inject (this");
   PrintContinuedLine("option can be repeated for");
   PrintContinuedLine("multiple libraries)");
 
   PrintArgHelp(
       "-n, --num-instances <count>",
-      "Number of instances to open"
-  );
+      "Number of instances to open");
 }

--- a/SGGL/src/help_printer.c
+++ b/SGGL/src/help_printer.c
@@ -32,6 +32,8 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <windows.h>
+#include <shlwapi.h>
 
 enum CONSTANTS {
   ARG_OPTION_LEN = 36,
@@ -59,9 +61,13 @@ static void PrintContinuedLine(
   printf(kFormatContinueString, ' ', description);
 }
 
-void PrintHelp(const wchar_t* current_program) {
-  wprintf(L"Usage: %ls [options] \n", current_program);
-  printf("Options: \n");
+/**
+ * External
+ */
+
+void Help_PrintText(const wchar_t* program_path) {
+  wprintf(L"Usage: %ls [options]\n", PathFindFileNameW(program_path));
+  printf("Options:\n");
 
   PrintArgHelp("-g, --game <program>", "Game to execute");
 

--- a/SGGL/src/help_printer.c
+++ b/SGGL/src/help_printer.c
@@ -42,22 +42,22 @@ enum {
   kDescriptionLength = 72 - kArgOptionLength - 2
 };
 
-#define FORMAT_STRING "  %-34s %s\n"
-#define FORMAT_CONTINUE_STRING "%36c %s\n"
+#define FORMAT_STRING L"  %-34s %s\n"
+#define FORMAT_CONTINUE_STRING L"%36c %s\n"
 
 static void PrintArgHelp(
-    const char* arg_option,
-    const char* description) {
-  assert(strlen(arg_option) < kArgOptionLength);
-  assert(strlen(description) < kDescriptionLength);
+    const wchar_t* arg_option,
+    const wchar_t* description) {
+  assert(wcslen(arg_option) < kArgOptionLength);
+  assert(wcslen(description) < kDescriptionLength);
 
-  printf(FORMAT_STRING, arg_option, description);
+  wprintf(FORMAT_STRING, arg_option, description);
 }
 
-static void PrintContinuedLine(const char* description) {
-  assert(strlen(description) < kDescriptionLength);
+static void PrintContinuedLine(const wchar_t* description) {
+  assert(wcslen(description) < kDescriptionLength);
 
-  printf(FORMAT_CONTINUE_STRING, ' ', description);
+  wprintf(FORMAT_CONTINUE_STRING, L' ', description);
 }
 
 /**
@@ -66,27 +66,27 @@ static void PrintContinuedLine(const char* description) {
 
 void Help_PrintText(const wchar_t* program_path) {
   wprintf(L"Usage: %ls [options]\n", PathFindFileNameW(program_path));
-  printf("Options:\n");
+  wprintf(L"Options:\n");
 
-  PrintArgHelp("-g, --game <program>", "Game to execute");
-
-  PrintArgHelp(
-      "-a, --gameargs <args>",
-      "Command line arguments to pass to");
-  PrintContinuedLine("the game");
+  PrintArgHelp(L"-g, --game <program>", L"Game to execute");
 
   PrintArgHelp(
-      "-k, --knowledge <library>",
-      "Path of Knowledge extension");
-  PrintContinuedLine("library");
+      L"-a, --gameargs <args>",
+      L"Command line arguments to pass to");
+  PrintContinuedLine(L"the game");
 
   PrintArgHelp(
-      "-l, --library <library>",
-      "Path of library to inject (this");
-  PrintContinuedLine("option can be repeated for");
-  PrintContinuedLine("multiple libraries)");
+      L"-k, --knowledge <library>",
+      L"Path of Knowledge extension");
+  PrintContinuedLine(L"library");
 
   PrintArgHelp(
-      "-n, --num-instances <count>",
-      "Number of instances to open");
+      L"-l, --library <library>",
+      L"Path of library to inject (this");
+  PrintContinuedLine(L"option can be repeated for");
+  PrintContinuedLine(L"multiple libraries)");
+
+  PrintArgHelp(
+      L"-n, --num-instances <count>",
+      L"Number of instances to open");
 }

--- a/SGGL/src/help_printer.h
+++ b/SGGL/src/help_printer.h
@@ -30,8 +30,16 @@
 #ifndef SGGL_HELP_PRINTER_H_
 #define SGGL_HELP_PRINTER_H_
 
-#include <wchar.h>
+#include <mdc/std/wchar.h>
 
-void PrintHelp(const wchar_t* current_program);
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+void Help_PrintText(const wchar_t* program_path);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif /* SGGL_HELP_PRINTER_H_ */

--- a/SGGL/src/main.c
+++ b/SGGL/src/main.c
@@ -61,7 +61,7 @@ int wmain(int argc, const wchar_t** argv) {
 
   /* Validate args. */
   if (!ValidateArgs(argc, argv)) {
-    PrintHelp(argv[0]);
+    Help_PrintText(argv[0]);
     printf("\nPress enter to exit... \n");
     getc(stdin);
 


### PR DESCRIPTION
These changes refactor the help printer, so that wide character functions are used, and only the file name is printed in the help text.