### PR TITLE
Fix arg parse crash

### DIFF
--- a/SGGL/src/args_parser.c
+++ b/SGGL/src/args_parser.c
@@ -78,7 +78,7 @@ static void ParseInjectLibraryPath(
       <= args->inject_library_paths_count) {
     Mdc_Error_ExitOnGeneralError(
         L"Error",
-        L"Library count changed during execution. Please rerun the program "
+        L"Library count changed during execution. Please run the program "
             L"again.",
         __FILEW__,
         __LINE__);
@@ -159,7 +159,7 @@ static int ArgParseFuncTableEntry_CompareKey(
 static int ArgParseFuncTableEntry_CompareKeyAsVoid(
     const void* entry1,
     const void* entry2) {
-  return wcscmp(entry1, entry2);
+  return ArgParseFuncTableEntry_CompareKey(entry1, entry2);
 }
 
 static const struct ArgParseFuncTableEntry kArgParseFuncSortedTable[] = {


### PR DESCRIPTION
These changes fix a crash that where the game path always being null. The arg parsing code was causing the crash.